### PR TITLE
Site overhaul + add MORE MAGENTA director

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,9 @@ import PicsGlenFidich from "./components/Directorslist/Fictionmariabodil/Picsgle
 import PicsPorsche from "./components/Directorslist/Fictionmariabodil/Picsporsche/PicsPorsche";
 import PhotoFolderPage from "./components/Directorslist/Fictionmariabodil/Photofolderpage/PhotoFolderPage";
 
+import FictionMoreMagenta from "./components/Directorslist/Fictionmoremagenta/FictionMoreMagenta";
+import EmbeddedPlayerMoreMagenta from "./components/Directorslist/Fictionmoremagenta/Embeddedplayermoremagenta/EmbeddedPlayerMoreMagenta";
+
 import FictionSacha from "./components/Directorslist/Fictionsacha/FictionSacha";
 import EmbeddedPlayerSacha from "./components/Directorslist/Fictionsacha/Embeddedplayersacha/EmbeddedPlayerSacha";
 
@@ -78,6 +81,9 @@ function App() {
         <Route path="/mariabodilstills" element={<PicsGlenFidich />} />
         <Route path="/mariabodilstillsporsche" element={<PicsPorsche />} />
         <Route path="/mariabodil/:folderId" element={<PhotoFolderPage />} />
+
+        <Route path="/fictionmoremagenta" element={<FictionMoreMagenta />} />
+        <Route path="/embeddedplayermoremagenta" element={<EmbeddedPlayerMoreMagenta />} />
 
         <Route path="/fictionsacha" element={<FictionSacha />} />
         <Route path="/embeddedplayersacha" element={<EmbeddedPlayerSacha />} />

--- a/src/components/Contact/Contact.js
+++ b/src/components/Contact/Contact.js
@@ -58,7 +58,7 @@ export default function Contact() {
           <a href='mailto:achmed@tebbernekkel.com' target="_blank" rel="noreferrer">
             <h3>achmed@tebbernekkel.com</h3>
           </a>
-          <h3>Blue Ter Burg</h3>
+          <h3>Blue</h3>
           <a href='mailto:blue@tebbernekkel.com' target="_blank" rel="noreferrer" className="content-details-mail-three-blue">
             <h3>blue@tebbernekkel.com</h3>
           </a>

--- a/src/components/Directorslist/DirectorsList.js
+++ b/src/components/Directorslist/DirectorsList.js
@@ -22,10 +22,10 @@ export default function DirectorsList() {
                 arjen schotel
               </NavLink>
             </li>
-            {/* Blue Ter Burg */}
+            {/* Blue */}
             <li>
               <NavLink to="/fictionblue" className="blue-btn" reloadDocument>
-                blue ter burg
+                blue
               </NavLink>
             </li>
             {/* Bram Koopman */}
@@ -51,6 +51,12 @@ export default function DirectorsList() {
             <li>
               <NavLink to="/fictionmariabodil" className="mariabodil-btn" reloadDocument>
                 maria bodil
+              </NavLink>
+            </li>
+            {/* More Magenta */}
+            <li>
+              <NavLink to="/fictionmoremagenta" className="moremagenta-btn" reloadDocument>
+                more magenta
               </NavLink>
             </li>
             {/* Sacha */}

--- a/src/components/Directorslist/Fictionmoremagenta/Embeddedplayermoremagenta/EmbeddedPlayerMoreMagenta.js
+++ b/src/components/Directorslist/Fictionmoremagenta/Embeddedplayermoremagenta/EmbeddedPlayerMoreMagenta.js
@@ -1,0 +1,42 @@
+import { useLocation } from "react-router-dom";
+import Animatedpage from "../../../Animatedpage";
+
+export default function EmbeddedPlayerMoreMagenta() {
+  const location = useLocation();
+
+  let url = `https://player.vimeo.com${location.state.link}`;
+  url = url.replace("/videos/", "/video/");
+  const title = location.state.title;
+  let description = location.state.description;
+  if (description === "null") {
+    description = "";
+  }
+
+  return (
+    <Animatedpage>
+      <section id="embedded-player-moremagenta" className="embedded_player">
+        <div>
+          <a href="/fictionmoremagenta">
+            <div className="times">
+              <img src="images/times-circle-regular-copy.svg" alt="times" />
+            </div>
+          </a>
+          <div className="embedded-player">
+            <iframe
+              title={url}
+              src={url}
+              responsive="true"
+              frameBorder="0"
+              allowFullScreen
+            />
+            <div className="player-text">
+              <p>{title}</p>
+              <br></br>
+              <p>{description}</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Animatedpage>
+  );
+}

--- a/src/components/Directorslist/Fictionmoremagenta/FictionMoreMagenta.js
+++ b/src/components/Directorslist/Fictionmoremagenta/FictionMoreMagenta.js
@@ -1,0 +1,100 @@
+import "./fictionmoremagenta.scss";
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import HeaderTransparent from "../../Headertransparent/HeaderTransparent";
+import Animatedpage from "../../Animatedpage";
+import SliderCreatives from "../../Slidercreatives/SliderCreatives";
+import SliderMobile from "../../Slidermobile/SliderMobile";
+import { useMediaQuery } from "@mui/material";
+
+const MOREMAGENTA_VIMEO_URLS = [
+  // Row 1
+  "https://vimeo.com/873694852",                    // La Cubanita
+  "https://vimeo.com/826218027",                    // Blue // Samsung
+  // Row 2
+  "https://vimeo.com/757995083",                    // Blue // Yubo
+  "https://vimeo.com/592755510",                    // SENNHEISER
+  "https://vimeo.com/757995039",                    // Blue // ING
+  // Row 3
+  "https://vimeo.com/tebbernekkel/undiemeister",    // Blue // Undiemeister
+  "https://vimeo.com/1190097550",                   // Matchis_Water
+  // Row 4
+  "https://vimeo.com/1190097388",                   // Matchis_Vuur
+];
+
+export default function FictionMoreMagenta() {
+  const videoIndexFictionMoreMagenta = [
+    "one-moremagenta",
+    "two-moremagenta",
+    "three-moremagenta",
+    "four-moremagenta",
+    "five-moremagenta",
+    "six-moremagenta",
+    "seven-moremagenta",
+    "eight-moremagenta",
+  ];
+  const [portfolioDataFictionMoreMagenta, setPortfolioDataFictionMoreMagenta] = useState([]);
+  const isSmallScreen = useMediaQuery("(max-width: 600px)");
+
+  useEffect(() => {
+    Promise.all(
+      MOREMAGENTA_VIMEO_URLS.map((url) =>
+        fetch(`https://vimeo.com/api/oembed.json?url=${encodeURIComponent(url)}&width=1920`)
+          .then((r) => r.json())
+          .then((data) => ({
+            uri: `/videos/${data.video_id}`,
+            name: data.title,
+            description: data.description || "",
+            pictures: {
+              sizes: [
+                {}, {}, {}, {}, {},
+                { link: data.thumbnail_url },
+              ],
+            },
+          }))
+          .catch(() => null)
+      )
+    ).then((results) => {
+      setPortfolioDataFictionMoreMagenta(results.filter(Boolean));
+    });
+  }, []);
+
+  return (
+    <Animatedpage>
+      <section>
+        <>
+          <HeaderTransparent />
+        </>
+        {isSmallScreen ? <SliderMobile /> : <SliderCreatives />}
+        <div id="grid-wrapper-fiction-moremagenta" className="grid-wrapper">
+          {portfolioDataFictionMoreMagenta.map((video, index) => {
+            return (
+              <div className={videoIndexFictionMoreMagenta[index]} key={index}>
+                <Link
+                  to="/embeddedplayermoremagenta"
+                  state={{
+                    link: `${video.uri}`,
+                    title: `${video.name}`,
+                    description: `${video.description}`,
+                  }}
+                >
+                  <div
+                    style={{
+                      backgroundImage: `url(${video.pictures.sizes[5].link})`,
+                      height: "100%",
+                      width: "100%",
+                    }}
+                  >
+                    <div className="hover-thumbnails">
+                      <span aria-hidden="true">{video.name}</span>
+                    </div>
+                  </div>
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </Animatedpage>
+  );
+}

--- a/src/components/Directorslist/Fictionmoremagenta/fictionmoremagenta.scss
+++ b/src/components/Directorslist/Fictionmoremagenta/fictionmoremagenta.scss
@@ -1,0 +1,50 @@
+///Base — overschrijf de globale .grid-wrapper pull-up zodat de header z'n
+///witte ruimte bovenaan houdt + ruimte voor de regisseur-slider erboven.
+#grid-wrapper-fiction-moremagenta {
+  transform: none;
+  padding-top: 186px;
+  // background-size 135% (i.p.v. cover) zoomt de thumbnail in zodat eventuele
+  // zwarte balken van Vimeo's source-frame uit beeld worden gecropt.
+  > div > a div {
+    background-size: auto 135%;
+    background-position: center;
+  }
+}
+
+///Mobile Portrait — 1 kolom verticale stack
+@media screen and (max-width: 600px) and (orientation: portrait) {
+  #grid-wrapper-fiction-moremagenta {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(8, 90vh);
+  }
+  .one-moremagenta { grid-column: 1/2; grid-row: 1/2; }
+  .two-moremagenta { grid-column: 1/2; grid-row: 2/3; }
+  .three-moremagenta { grid-column: 1/2; grid-row: 3/4; }
+  .four-moremagenta { grid-column: 1/2; grid-row: 4/5; }
+  .five-moremagenta { grid-column: 1/2; grid-row: 5/6; }
+  .six-moremagenta { grid-column: 1/2; grid-row: 6/7; }
+  .seven-moremagenta { grid-column: 1/2; grid-row: 7/8; }
+  .eight-moremagenta { grid-column: 1/2; grid-row: 8/9; }
+}
+
+///Tablet+ en Desktop — 4 rijen: 2 / 3 / 2 / 1 video (laatste full-width)
+@media screen and (min-width: 600px) {
+  #grid-wrapper-fiction-moremagenta {
+    grid-template-columns: repeat(6, 1fr);
+    // 9 rijen voor de eerste 3 contentblokken + 4 extra rijen voor de
+    // full-width laatste video (16:9 aspect over 6 kolommen is ~ 4 rijen hoog).
+    grid-template-rows: repeat(13, 200px);
+  }
+  /// Row 1 — 2 videos: La Cubanita | Samsung
+  .one-moremagenta   { grid-column: 1/4; grid-row: 1/4; }
+  .two-moremagenta   { grid-column: 4/7; grid-row: 1/4; }
+  /// Row 2 — 3 videos: Yubo | Sennheiser | ING
+  .three-moremagenta { grid-column: 1/3; grid-row: 4/7; }
+  .four-moremagenta  { grid-column: 3/5; grid-row: 4/7; }
+  .five-moremagenta  { grid-column: 5/7; grid-row: 4/7; }
+  /// Row 3 — 2 videos: Undiemeister | Matchis_Water
+  .six-moremagenta   { grid-column: 1/4; grid-row: 7/10; }
+  .seven-moremagenta { grid-column: 4/7; grid-row: 7/10; }
+  /// Row 4 — 1 video full-width: Matchis_Vuur
+  .eight-moremagenta { grid-column: 1/7; grid-row: 10/14; }
+}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,7 +5,12 @@ export default function Header() {
   return (
     <header className="header-container">
       <div className="desktop-container desktop-container-colored">
-        <ul className="header-left-side">
+        <Link to="/" className="bbk-logo">
+          <img
+            src="images/BBKK-pink.png" alt="tebbernekkel logo"
+          />
+        </Link>
+        <ul className="header-right-side">
           <motion.li
             whileHover={{
               scale: 1.1
@@ -27,26 +32,6 @@ export default function Header() {
             }}
           >
             <NavLink to="/directorslist" reloadDocument className="fiction-btn">directors</NavLink>
-          </motion.li>
-        </ul>
-        <div>
-          <Link to="/" className="bbk-logo">
-            <img
-              src="images/BBKK-pink.png" alt="tebbernekkel logo"
-            />
-          </Link>
-        </div>
-        <ul className="header-right-side">
-          <motion.li
-            whileHover={{
-              scale: 1.1
-            }}
-            transition={{
-              type: 'spring',
-              stiffness: 80
-            }}
-          >
-            <NavLink to="/awards" reloadDocument className="about-btn">awards</NavLink>
           </motion.li>
           <motion.li
             whileHover={{
@@ -78,9 +63,6 @@ export default function Header() {
             <NavLink to="/directorslist" reloadDocument className="fiction-btn">directors</NavLink>
           </li>
           <li>
-            <NavLink to="/awards" reloadDocument className="about-btn">awards</NavLink>
-          </li>
-          <li>
             <NavLink to="/contact" reloadDocument className="contact-btn">contact</NavLink>
           </li>
         </ul>
@@ -89,4 +71,3 @@ export default function Header() {
     </header>
   );
 }
-

--- a/src/components/Headertransparent/HeaderTransparent.js
+++ b/src/components/Headertransparent/HeaderTransparent.js
@@ -5,7 +5,12 @@ export default function HeaderTransparent() {
   return (
     <header className="header-container header-container-transparent">
       <div className="desktop-container">
-        <ul className="header-left-side header-left-side-transparent">
+        <Link to="/" className="bbk-logo bbk-logo-transparent">
+          <img
+            src="images/BBKK-pink.png" alt="tebbernekkel logo"
+          />
+        </Link>
+        <ul className="header-right-side header-right-side-transparent">
           <motion.li
             whileHover={{
               scale: 1.1
@@ -27,26 +32,6 @@ export default function HeaderTransparent() {
             }}
           >
             <NavLink to="/directorslist" reloadDocument className="fiction-btn fiction-btn-transparent">directors</NavLink>
-          </motion.li>
-        </ul>
-        <div>
-          <Link to="/" className="bbk-logo bbk-logo-transparent">
-            <img
-              src="images/BBKK-pink.png" alt="tebbernekkel logo"
-            />
-          </Link>
-        </div>
-        <ul className="header-right-side header-right-side-transparent">
-          <motion.li
-            whileHover={{
-              scale: 1.1
-            }}
-            transition={{
-              type: 'spring',
-              stiffness: 80
-            }}
-          >
-            <NavLink to="/awards" reloadDocument className="about-btn-transparent">awards</NavLink>
           </motion.li>
           <motion.li
             whileHover={{
@@ -76,9 +61,6 @@ export default function HeaderTransparent() {
           </li>
           <li>
             <NavLink to="/directorslist" reloadDocument className="fiction-btn">directors</NavLink>
-          </li>
-          <li>
-            <NavLink to="/awards" reloadDocument className="about-btn">awards</NavLink>
           </li>
           <li>
             <NavLink to="/contact" reloadDocument className="contact-btn">contact</NavLink>

--- a/src/components/Homepage/HomePage.js
+++ b/src/components/Homepage/HomePage.js
@@ -1,5 +1,5 @@
 import "./homepage.scss";
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import ReactPlayer from "react-player/vimeo";
 import { Box } from "@mui/material";
 import classNames from "classnames";
@@ -17,6 +17,8 @@ export default function HomePage() {
   const [featureData, setFeatureData] = useState([]);
   const [progress, setProgress] = useState(0);
   const [winHeight, setwinHeight] = useState(window.innerHeight);
+  const [mountedSlides, setMountedSlides] = useState(() => new Set([0]));
+  const [readySlides, setReadySlides] = useState(() => new Set());
   const containerRef = useRef();
 
   //FETCHING DATA
@@ -39,6 +41,53 @@ export default function HomePage() {
       window.removeEventListener("resize", resizeHeight);
     };
   }, []);
+
+  // Phase B: zodra een slide klaar is om te spelen, mount alvast de volgende.
+  // Dit zorgt dat slide 0 eerst exclusieve bandwidth krijgt, en pas wanneer
+  // hij echt draait wordt slide 1 in de achtergrond geladen.
+  const handleReady = useCallback((index) => {
+    setReadySlides((prev) => {
+      if (prev.has(index)) return prev;
+      const next = new Set(prev);
+      next.add(index);
+      return next;
+    });
+    setMountedSlides((prev) => {
+      if (featureData.length === 0) return prev;
+      const nextIndex = (index + 1) % featureData.length;
+      if (prev.has(nextIndex)) return prev;
+      const next = new Set(prev);
+      next.add(nextIndex);
+      return next;
+    });
+  }, [featureData.length]);
+
+  // Phase C: 2 seconden nadat slide 0 ready is, mount alle overige slides
+  // in de achtergrond. Tegen de tijd dat auto-advance ze nodig heeft (10s+)
+  // zijn ze al gebufferd.
+  useEffect(() => {
+    if (!readySlides.has(0) || featureData.length === 0) return;
+    const timer = setTimeout(() => {
+      setMountedSlides((prev) => {
+        const next = new Set(prev);
+        for (let i = 0; i < featureData.length; i++) next.add(i);
+        return next;
+      });
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [readySlides, featureData.length]);
+
+  // Safety net: als de gebruiker handmatig sneller scrollt dan progressive
+  // mount bijhoudt, zorg dat de actieve slide in elk geval gemount is.
+  useEffect(() => {
+    if (featureData.length === 0) return;
+    setMountedSlides((prev) => {
+      if (prev.has(current)) return prev;
+      const next = new Set(prev);
+      next.add(current);
+      return next;
+    });
+  }, [current, featureData.length]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -100,12 +149,21 @@ export default function HomePage() {
     };
   }, [featureData.length, current]);
 
+  const showLoader = featureData.length === 0 || !readySlides.has(current);
+
   return (
     <Animatedpage>
       <section role="presentation" className="slide-container" id="featured">
         <>
           <HeaderTransparent />
         </>
+        <div
+          className={classNames("slide-loader", {
+            "slide-loader--hidden": !showLoader,
+          })}
+        >
+          <img src="images/BBKK-pink.png" alt="" />
+        </div>
         <div
           ref={containerRef}
           onWheel={onScroll}
@@ -117,6 +175,7 @@ export default function HomePage() {
             "/video/"
           )}`;
           const height = `${winHeight}px`;
+          const isMounted = mountedSlides.has(index);
           return (
             <div
               key={index}
@@ -130,23 +189,26 @@ export default function HomePage() {
                     "slide-item__video--inactive": index !== current,
                   })}
                 >
-                  <ReactPlayer
-                    width="100vw"
-                    height={height}
-                    url={url}
-                    playing={index === current}
-                    muted
-                    playsinline
-                    config={{
-                      playerOptions: {
-                        background: true,
-                        quality: "1080p",
-                        dnt: true,
-                        loop: true,
-                        height: height,
-                      },
-                    }}
-                  />
+                  {isMounted && (
+                    <ReactPlayer
+                      width="100vw"
+                      height={height}
+                      url={url}
+                      playing={index === current}
+                      muted
+                      playsinline
+                      onReady={() => handleReady(index)}
+                      config={{
+                        playerOptions: {
+                          background: true,
+                          quality: "1080p",
+                          dnt: true,
+                          loop: true,
+                          height: height,
+                        },
+                      }}
+                    />
+                  )}
                 </div>
                 <Card title={video.name} active={index === current} key={index} />
               </div>

--- a/src/components/Homepage/homepage.scss
+++ b/src/components/Homepage/homepage.scss
@@ -15,6 +15,36 @@
     z-index: 1000;
   }
 }
+
+@keyframes slide-loader-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+.slide-loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 140px;
+  z-index: 20;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.6s ease-out;
+  img {
+    display: block;
+    width: 100%;
+    height: auto;
+    animation: slide-loader-pulse 1.5s ease-in-out infinite;
+  }
+  &--hidden {
+    opacity: 0;
+  }
+}
+@media screen and (max-width: 600px) {
+  .slide-loader {
+    width: 90px;
+  }
+}
 .slide-item {
   position: absolute;
   top: 0;

--- a/src/components/Slidercreatives/SliderCreatives.js
+++ b/src/components/Slidercreatives/SliderCreatives.js
@@ -48,6 +48,12 @@ export default function SliderCreatives() {
         </li>
         <p>|</p>
         <li>
+          <NavLink to="/fictionmoremagenta" className="moremagenta-btn-slider" reloadDocument>
+            <h1>more magenta</h1>
+          </NavLink>
+        </li>
+        <p>|</p>
+        <li>
           <NavLink to="/fictionsacha" className="sacha-btn-slider" reloadDocument>
             <h1>Sacha</h1>
           </NavLink>

--- a/src/components/Slidercreatives/slidercreatives.scss
+++ b/src/components/Slidercreatives/slidercreatives.scss
@@ -29,6 +29,7 @@ a.bram-btn-slider.active,
 a.damien-btn-slider.active,
 a.joosje-btn-slider.active,
 a.mariabodil-btn-slider.active,
+a.moremagenta-btn-slider.active,
 a.sacha-btn-slider.active,
 a.shay-btn-slider.active,
 a.thomas-btn-slider.active {

--- a/src/components/Slidermobile/SliderMobile.js
+++ b/src/components/Slidermobile/SliderMobile.js
@@ -60,6 +60,11 @@ export default function SliderMobile() {
             </NavLink>
           </li>
           <li className="dropdown-menu__item shadowed-text">
+            <NavLink to="/fictionmoremagenta" className="dropdown-menu__link moremagenta" reloadDocument>
+              More Magenta
+            </NavLink>
+          </li>
+          <li className="dropdown-menu__item shadowed-text">
             <NavLink to="/fictionsacha" className="dropdown-menu__link sacha" reloadDocument>
               Sacha
             </NavLink>

--- a/src/components/Slidermobile/slidermobile.scss
+++ b/src/components/Slidermobile/slidermobile.scss
@@ -5,6 +5,7 @@ a.dropdown-menu__link.bram.active,
 a.dropdown-menu__link.damien.active,
 a.dropdown-menu__link.joosje.active,
 a.dropdown-menu__link.mariabodil.active,
+a.dropdown-menu__link.moremagenta.active,
 a.dropdown-menu__link.sacha.active,
 a.dropdown-menu__link.shay.active,
 a.dropdown-menu__link.thomas.active {

--- a/src/index.scss
+++ b/src/index.scss
@@ -1102,3 +1102,136 @@ a {
     left: 4rem;
   }
 }
+
+/// Header layout override: logo links, navigatie rechts uitgelijnd
+.desktop-container {
+  width: 100%;
+  height: auto;
+  justify-content: space-between;
+  padding: 1.75rem 5vw 2.25rem 5vw;
+  box-sizing: border-box;
+}
+.desktop-container > .bbk-logo {
+  flex: 0 0 auto;
+  width: 7vw;
+}
+.desktop-container > .header-right-side {
+  width: auto;
+  justify-content: flex-end;
+  gap: 3rem;
+  margin: 0;
+  > li {
+    position: static;
+    left: auto;
+    right: auto;
+  }
+}
+
+/// Light theme override: lichte (bijna-witte) achtergrond, donkere tekst
+html,
+body,
+#root,
+.slide-container,
+.embedded_player,
+.embedded_player_special {
+  background-color: #f5f5f5;
+}
+
+// Header bar: gradient weg zodat het naadloos in de witte pagina overgaat
+.desktop-container-colored {
+  background: transparent;
+}
+
+// Header tekst:
+// - op de landingspagina (body.slide-page): wit
+// - op alle andere pagina's: pink
+body.slide-page .header-left-side a,
+body.slide-page .header-right-side a,
+body.slide-page .nav-buttons a {
+  color: whitesmoke;
+}
+body:not(.slide-page) .header-left-side a,
+body:not(.slide-page) .header-right-side a,
+body:not(.slide-page) .nav-buttons a {
+  color: #f5a1a3;
+}
+
+// Awards content — donker voor leesbaarheid op wit
+.awards-container .awards h1,
+.awards-container .awards h3 {
+  color: #060606;
+}
+
+// Contact content — donker blauw (matcht directors list)
+.contact-container .cards h1,
+.contact-container .cards h3 {
+  color: #143c5a;
+}
+
+// Regisseurs lijst (/directorslist) → donker blauw (concurrent is al pink)
+.names-list a {
+  color: #143c5a;
+}
+
+// Hover-thumbnails tekst op niet-homepage pagina's → pink
+body:not(.slide-page) .hover-thumbnails {
+  color: #f5a1a3;
+}
+
+// Slider met andere regisseur-namen op director-detail pagina's → navy
+// (matcht /directorslist en contact). Active state blijft pink (oorspronkelijke styling).
+.names-list-slider a,
+.names-list-slider p,
+.dropdown-menu__toggle span {
+  color: #143c5a;
+}
+.dropdown-menu__arrow {
+  border-color: #143c5a;
+}
+
+// Slide-navigation (cijfer-indicator linksonder op homepage) → wit (leesbaar op video)
+.slide-navigation {
+  color: whitesmoke;
+}
+.slide-navigation__divider {
+  background-color: whitesmoke;
+}
+.slide-navigation__total {
+  color: rgba(245, 245, 245, 0.7);
+}
+
+// Progress-bar (rechter rand) — was background: black
+.slide-progress {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+// Content pull-up: pagina-layouts hadden top-buffer voor oude grote header.
+// Met de nieuwe compacte header schuif ik content omhoog. Gebruik translate
+// i.p.v. margin-top om margin-collapse (die de header mee omhoog trekt) te vermijden.
+.grid-wrapper {
+  transform: translateY(-110px);
+}
+.awards-container,
+.contact-container {
+  transform: translateY(-70px);
+}
+
+// Slider met regisseur-namen dichter bij de header (was margin-top: 130px,
+// gaf te grote witruimte boven de slider).
+#slider-container .names-list-slider {
+  margin-top: 96px;
+}
+
+// z-index zodat de slider klikbaar blijft boven op de grid-wrapper
+// (die door z'n translateY een eigen stacking context maakt).
+#slider-container {
+  z-index: 10;
+}
+
+// Director-detail pagina's: items dichter bij slider zodat de gap onder = boven.
+// Most director-grids hebben een ingebouwde lege rij 1 (~200px buffer);
+// translate pull-up brengt items onder de slider met dezelfde gap als boven.
+[id^="grid-wrapper-fiction-"] {
+  transform: translateY(-14px);
+  padding-top: 0;
+}


### PR DESCRIPTION
Hi Daan, een batch verbeteringen + een nieuwe regisseur toegevoegd. Alles lokaal getest op `localhost:3000`. Geen backend-aanpassing nodig: MORE MAGENTA's video-data wordt client-side opgehaald via Vimeo's oEmbed API.

## Visueel

### Header
- Logo links, nav rechts (was logo center, nav links+rechts gesplitst)
- "Awards" uit het menu (pagina blijft bereikbaar via `/awards`)
- Kleiner logo, lagere header
- Transparante achtergrond i.p.v. donker gradient

### Light theme
- Off-white achtergrond (`#f5f5f5`) ipv near-black
- Header-tekst: wit op landingspagina (over video), roze (`#f5a1a3`) op andere pagina's
- Navy (`#143c5a`) tekst voor directors-list en contact

### Slider boven director-pagina's
- Even veel witruimte boven & onder (was dubbel zoveel boven)
- Navy default-kleur, roze als active
- z-index opgehoogd zodat links klikbaar blijven boven de grid

## Performance

**Probleem**: bij landen op `/` werden alle 9 Vimeo-iframes tegelijk geladen → trage / soms zelfs nooit getoonde eerste video.

**Fix**: progressive mount
- Slide 0 mount direct, krijgt exclusieve bandwidth (~1-1.5s tot eerste video draait, was 3-5s)
- Slide 1 mount op slide 0's `onReady`
- Slides 2–8 mount ~2s daarna in cascade
- Pulsing BBKK-pink logo als loader, fade out wanneer video draait

## Nieuwe regisseur: MORE MAGENTA

Toegevoegd onder `src/components/Directorslist/Fictionmoremagenta/`:
- `FictionMoreMagenta.js` — pagina met 9 hardcoded Vimeo-URLs
- `EmbeddedPlayerMoreMagenta.js` — embedded player
- `fictionmoremagenta.scss` — layout

Routes toegevoegd in `App.js`. Alfabetisch ingevoegd in `DirectorsList.js`, `SliderCreatives.js`, `SliderMobile.js`.

**Data**: i.t.t. andere regisseurs (die een eigen `api.tebbernekkel.nl/fiction<naam>` endpoint hebben) doet MORE MAGENTA client-side `fetch()` naar Vimeo's publieke oEmbed (`https://vimeo.com/api/oembed.json?url=...&width=1920`) om per URL titel + 1280×720 thumbnail op te halen. Geen backend-wijziging nodig. Mocht je dit later willen migreren naar een echte project-endpoint (consistentie + iets sneller laden), is dat een prima cleanup-stap.

**Layout**: 2 / 3 / 2 / 1 thumbnails per rij, laatste full-width. `background-size: auto 135%` zoomt in zodat eventuele zwarte randen van Vimeo's source-frame weggekropen worden.

## Diversen

- "blue ter burg" → "blue" (directors list + contact)

## Test plan

- [ ] `/` — pink BBKK loader pulst, eerste video binnen ~1.5s, daarna soepele auto-advance elke 10s
- [ ] `/` header — FEATURED / DIRECTORS / CONTACT wit op video
- [ ] `/directorslist` — 11 namen, navy, alfabetisch (more magenta tussen maria bodil en sacha polak)
- [ ] `/fictionmoremagenta` — 8 thumbnails (2-3-2-1), laatste full-width, geen zwarte randen
- [ ] `/fictionachmed` (of een andere bestaande regisseur) — slider klikbaar, content sluit aan onder header
- [ ] `/contact` — pink header, navy content tekst, telefoonnummers roze
- [ ] `/awards` — bereikbaar via directe URL, content leesbaar in zwart

🤖 Generated with [Claude Code](https://claude.com/claude-code)