### PR TITLE
Fix: top-row thumbnails op director-pagina's waren onklikbaar

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1224,8 +1224,15 @@ body:not(.slide-page) .hover-thumbnails {
 
 // z-index zodat de slider klikbaar blijft boven op de grid-wrapper
 // (die door z'n translateY een eigen stacking context maakt).
+// pointer-events: none op de container zorgt dat z'n 100vh lege gebied
+// geen klikken op de top-row thumbnails meer onderschept; .names-list-slider
+// krijgt zelf weer auto zodat de director-links wel klikbaar blijven.
 #slider-container {
   z-index: 10;
+  pointer-events: none;
+}
+.names-list-slider {
+  pointer-events: auto;
 }
 
 // Director-detail pagina's: items dichter bij slider zodat de gap onder = boven.


### PR DESCRIPTION
Hoi @DaanR37 — kleine follow-up op PR #4 (al gemerged + gedeployed). De top-row thumbnails op de director-pagina's (achmed, arjen, blue, etc.) zijn live niet klikbaar.

**Probleem:** in PR #4 zette ik z-index 10 op #slider-container zodat de slider klikbaar bleef. Bijwerking: die wrapper is 100vh hoog en onderschept nu klikken op alle thumbnails in z'n bereik (de top-row).

**Fix:** pointer-events: none op de container (klikken gaan er doorheen), pointer-events: auto op .names-list-slider (slider-links blijven werken). Geen visuele wijziging. Eén bestand: src/index.scss.

Lokaal getest, alle thumbnail-clicks routen naar embedded player, slider-clicks werken nog steeds.

Na merge: even `npm run build` + uploaden naar Intercube (zelfde route als PR #4).

Thx broertje 🙏