### PR TITLE
Fix: top-row klikbaarheid + mobile witte balk MoreMagenta

### DIFF
--- a/src/components/Directorslist/Fictionmoremagenta/fictionmoremagenta.scss
+++ b/src/components/Directorslist/Fictionmoremagenta/fictionmoremagenta.scss
@@ -1,8 +1,9 @@
 ///Base — overschrijf de globale .grid-wrapper pull-up zodat de header z'n
-///witte ruimte bovenaan houdt + ruimte voor de regisseur-slider erboven.
+///witte ruimte bovenaan houdt. padding-top voor de regisseur-slider wordt
+///alleen op tablet+desktop toegepast (mobiel heeft een dropdown i.p.v. een
+///horizontale slider, dus daar zou de padding een witte balk creëren).
 #grid-wrapper-fiction-moremagenta {
   transform: none;
-  padding-top: 186px;
   // background-size 135% (i.p.v. cover) zoomt de thumbnail in zodat eventuele
   // zwarte balken van Vimeo's source-frame uit beeld worden gecropt.
   > div > a div {
@@ -30,6 +31,7 @@
 ///Tablet+ en Desktop — 4 rijen: 2 / 3 / 2 / 1 video (laatste full-width)
 @media screen and (min-width: 600px) {
   #grid-wrapper-fiction-moremagenta {
+    padding-top: 186px;            // ruimte voor de horizontale regisseur-slider
     grid-template-columns: repeat(6, 1fr);
     // 9 rijen voor de eerste 3 contentblokken + 4 extra rijen voor de
     // full-width laatste video (16:9 aspect over 6 kolommen is ~ 4 rijen hoog).

--- a/src/index.scss
+++ b/src/index.scss
@@ -1224,15 +1224,26 @@ body:not(.slide-page) .hover-thumbnails {
 
 // z-index zodat de slider klikbaar blijft boven op de grid-wrapper
 // (die door z'n translateY een eigen stacking context maakt).
-// pointer-events: none op de container zorgt dat z'n 100vh lege gebied
-// geen klikken op de top-row thumbnails meer onderschept; .names-list-slider
-// krijgt zelf weer auto zodat de director-links wel klikbaar blijven.
+// pointer-events: none op de container + de slider zelf zorgt dat de
+// 100vh lege wrapper EN de lege ruimte links/rechts van de namen geen
+// klikken meer onderscheppen. Alleen de individuele <a>-links vangen
+// klikken op, zodat thumbnails eronder altijd klikbaar zijn.
 #slider-container {
   z-index: 10;
   pointer-events: none;
 }
 .names-list-slider {
+  pointer-events: none;
+}
+.names-list-slider a {
   pointer-events: auto;
+}
+
+// Hover-scale uit op de slider-namen — anders kan een geschaalde naam de
+// klik-zone van de buur-naam overlappen waardoor die buur kort onklikbaar lijkt.
+.names-list-slider a:hover,
+.names-list-slider a:hover h1 {
+  transform: none;
 }
 
 // Director-detail pagina's: items dichter bij slider zodat de gap onder = boven.


### PR DESCRIPTION
Hoi @DaanR37 — twee follow-up fixes:

## 1. Top-row thumbnails niet klikbaar (varieert per bezoeker)

**Probleem:** ondanks PR #5 (`pointer-events: none` op `#slider-container`) bleven sommige top-row thumbnails onklikbaar, en het verschilde per bezoeker. Visitors meldden specifiek Blue / Damien.

**Root cause:** `.names-list-slider` is full-width (`width: 100%`) met `pointer-events: auto`. De zichtbare namen staan in het midden, maar de lege strookjes links en rechts van die namen erfden ook auto en vingen klikken op. Combinatie met scroll-positie, font-swap delay, en het hover-scale effect dat naburige namen overlapt veroorzaakte inconsistente klikbaarheid.

**Fix:** pointer-events op `.names-list-slider` zelf naar `none` gezet, alleen de `<a>` children krijgen `pointer-events: auto`. Nu vangen alleen de echte zichtbare links klikken op — de lege flanken niet meer. Plus hover `transform: scale(1.1)` weggehaald om overlap-races met buurnamen uit te sluiten.

**Visuele impact:** alleen het hover-uitvergrooteffect op slider-namen is weg. Kleurverandering bij hover (cyan) blijft.

## 2. Witte balk bovenaan MoreMagenta op mobiel

**Probleem:** alleen op MoreMagenta toont mobiel een witte balk bovenaan.

**Root cause:** in `fictionmoremagenta.scss` stond `padding-top: 186px` op base-niveau (geldt op alle viewports). Bedoeld om ruimte te maken voor de horizontale `SliderCreatives` op desktop — die wordt op mobiel echter vervangen door een kleine dropdown (`SliderMobile`). Op mobiel was de 186px dus overbodig en zichtbaar als lege witte balk.

**Fix:** `padding-top: 186px` verplaatst naar het bestaande `@media (min-width: 600px)` blok. Op mobiel geen padding meer, op tablet+/desktop ongewijzigd.

**Visuele impact:** alleen op mobiel — witte balk weg. Desktop hetzelfde.

## Files changed
- `src/index.scss` (Issue 1)
- `src/components/Directorslist/Fictionmoremagenta/fictionmoremagenta.scss` (Issue 2)

## Deploy
Zoals altijd: PR mergen, `git pull origin master`, `npm run build`, build/ uploaden naar Intercube.

Thx broertje 🙏